### PR TITLE
Fix inventory concurrency with rowversion

### DIFF
--- a/src/Modules/SimplCommerce.Module.Inventory/Data/InventoryCustomModelBuilder.cs
+++ b/src/Modules/SimplCommerce.Module.Inventory/Data/InventoryCustomModelBuilder.cs
@@ -9,6 +9,10 @@ namespace SimplCommerce.Module.Inventory.Data
         public void Build(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Warehouse>().HasData(new Warehouse(1) { Name = "Default warehouse", AddressId = 1 });
+
+            modelBuilder.Entity<Stock>()
+                .Property(x => x.RowVersion)
+                .IsRowVersion();
         }
     }
 }

--- a/src/Modules/SimplCommerce.Module.Inventory/Models/Stock.cs
+++ b/src/Modules/SimplCommerce.Module.Inventory/Models/Stock.cs
@@ -1,5 +1,6 @@
 ﻿using SimplCommerce.Infrastructure.Models;
 using SimplCommerce.Module.Catalog.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace SimplCommerce.Module.Inventory.Models
 {
@@ -16,5 +17,8 @@ namespace SimplCommerce.Module.Inventory.Models
         public int Quantity { get; set; }
 
         public int ReservedQuantity { get; set; }
+
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
     }
 }

--- a/src/Modules/SimplCommerce.Module.Inventory/Services/StockService.cs
+++ b/src/Modules/SimplCommerce.Module.Inventory/Services/StockService.cs
@@ -68,7 +68,15 @@ namespace SimplCommerce.Module.Inventory.Services
             };
 
             _stockHistoryRepository.Add(stockHistory);
-            await _stockHistoryRepository.SaveChangesAsync();
+
+            try
+            {
+                await _stockHistoryRepository.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw;
+            }
 
             if (prevStockQuantity <= 0 && product.StockQuantity > 0)
             {

--- a/test/SimplCommerce.Module.Inventory.Tests/InventoryConcurrencyTests.cs
+++ b/test/SimplCommerce.Module.Inventory.Tests/InventoryConcurrencyTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using SimplCommerce.Infrastructure;
+using SimplCommerce.Infrastructure.Modules;
+using SimplCommerce.Module.Core;
+using SimplCommerce.Module.Core.Data;
+using SimplCommerce.Module.Catalog;
+using SimplCommerce.Module.Catalog.Models;
+using SimplCommerce.Module.Inventory;
+using SimplCommerce.Module.Inventory.Models;
+using SimplCommerce.Module.Inventory.Services;
+using Xunit;
+
+namespace SimplCommerce.Module.Inventory.Tests
+{
+    public class InventoryConcurrencyTests
+    {
+        private static DbContextOptions<SimplDbContext> CreateOptions(string name)
+        {
+            return new DbContextOptionsBuilder<SimplDbContext>()
+                .UseInMemoryDatabase(name)
+                .Options;
+        }
+
+        private static StockService CreateService(DbContextOptions<SimplDbContext> options, IMediator mediator)
+        {
+            var context = new SimplDbContext(options);
+            var stockRepo = new SimplCommerce.Module.Core.Data.Repository<Stock>(context);
+            var productRepo = new SimplCommerce.Module.Core.Data.Repository<Product>(context);
+            var historyRepo = new SimplCommerce.Module.Core.Data.Repository<StockHistory>(context);
+            return new StockService(stockRepo, productRepo, historyRepo, mediator);
+        }
+
+        [Fact]
+        public async Task ConcurrentOrders_TotalExceedingStock_ShouldFailOneOrder()
+        {
+            GlobalConfiguration.Modules = new List<ModuleInfo>
+            {
+                new ModuleInfo { Id = "SimplCommerce.Module.Core", Assembly = typeof(SimplCommerce.Module.Core.ModuleInitializer).Assembly },
+                new ModuleInfo { Id = "SimplCommerce.Module.Catalog", Assembly = typeof(SimplCommerce.Module.Catalog.ModuleInitializer).Assembly },
+                new ModuleInfo { Id = "SimplCommerce.Module.Inventory", Assembly = typeof(SimplCommerce.Module.Inventory.ModuleInitializer).Assembly }
+            };
+
+            var options = CreateOptions(Guid.NewGuid().ToString());
+
+            using (var seed = new SimplDbContext(options))
+            {
+                var product = new Product { Name = "Test", Slug = "test", HasOptions = false, IsPublished = true, StockQuantity = 5 };
+                typeof(Product).GetProperty("Id")!.SetValue(product, 1L);
+                seed.Add(product);
+                seed.Add(new Warehouse(1) { Name = "WH", AddressId = 1 });
+                seed.Add(new Stock { ProductId = 1, WarehouseId = 1, Quantity = 5 });
+                seed.SaveChanges();
+            }
+
+            var request = new StockUpdateRequest { ProductId = 1, WarehouseId = 1, AdjustedQuantity = -3 };
+
+            var mediator = new Mock<IMediator>();
+            var service1 = CreateService(options, mediator.Object);
+            var service2 = CreateService(options, mediator.Object);
+
+            var t1 = Task.Run(() => service1.UpdateStock(request));
+            var t2 = Task.Run(() => service2.UpdateStock(request));
+
+            var errors = await Task.WhenAll(
+                t1.ContinueWith(t => t.Exception?.InnerException),
+                t2.ContinueWith(t => t.Exception?.InnerException));
+
+            Assert.Contains(errors, e => e is DbUpdateConcurrencyException);
+            Assert.Contains(errors, e => e is null);
+
+            using var verify = new SimplDbContext(options);
+            var stock = await verify.Set<Stock>().FirstAsync();
+            Assert.Equal(2, stock.Quantity);
+        }
+    }
+}

--- a/test/SimplCommerce.Module.Inventory.Tests/InventoryCustomModelBuilderTests.cs
+++ b/test/SimplCommerce.Module.Inventory.Tests/InventoryCustomModelBuilderTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using SimplCommerce.Module.Inventory.Data;
+using SimplCommerce.Module.Inventory.Models;
+using Xunit;
+
+namespace SimplCommerce.Module.Inventory.Tests
+{
+    public class InventoryCustomModelBuilderTests
+    {
+        [Fact]
+        public void Build_ConfiguresRowVersionAsConcurrencyToken()
+        {
+            var modelBuilder = new ModelBuilder();
+            var builder = new InventoryCustomModelBuilder();
+            builder.Build(modelBuilder);
+
+            var entity = modelBuilder.Model.FindEntityType(typeof(Stock));
+            var property = entity.FindProperty(nameof(Stock.RowVersion));
+
+            Assert.True(property.IsConcurrencyToken);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
+        }
+    }
+}

--- a/test/SimplCommerce.Module.Inventory.Tests/SimplCommerce.Module.Inventory.Tests.csproj
+++ b/test/SimplCommerce.Module.Inventory.Tests/SimplCommerce.Module.Inventory.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MockQueryable.Moq" Version="7.0.1" />
     <PackageReference Include="Moq" Version="4.20.69" />

--- a/test/SimplCommerce.Module.Inventory.Tests/StockServiceTests.cs
+++ b/test/SimplCommerce.Module.Inventory.Tests/StockServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -87,6 +88,30 @@ namespace SimplCommerce.Module.Inventory.Tests
             Assert.Equal(Math.Max(0, prevStockQuantity + adjustedQuantity), newStockQuantity);
         }
 
+        [Fact]
+        public async Task UpdateStock_SaveChangesThrowsConcurrency_ShouldPropagateException()
+        {
+            // Arrange
+            InitializeMocks(1, 1);
+            _stockHistoryRepoMock.Setup(x => x.SaveChangesAsync()).ThrowsAsync(new DbUpdateConcurrencyException());
+            var service = new StockService(
+                _stockRepoMock.Object,
+                _productRepoMock.Object,
+                _stockHistoryRepoMock.Object,
+                _mediatorMock.Object);
+
+            var product = _productRepoMock.Object.Query().First();
+            var request = new StockUpdateRequest
+            {
+                AdjustedQuantity = 1,
+                ProductId = product.Id,
+                WarehouseId = _testWarehouse.Id,
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => service.UpdateStock(request));
+        }
+
         private void InitializeMocks(int productsCount, int stocksCount)
         {
             _stockRepoMock = new Mock<IRepository<Stock>>();
@@ -105,6 +130,7 @@ namespace SimplCommerce.Module.Inventory.Tests
             _stockRepoMock.Setup(x => x.Query())
                 .Returns(stocksMock);
             _stockRepoMock.Setup(x => x.AddRange(It.IsAny<IEnumerable<Stock>>()));
+            _stockRepoMock.Setup(x => x.SaveChangesAsync()).Returns(Task.CompletedTask);
 
             _productRepoMock = new Mock<IRepository<Product>>();
             var products = new Product[productsCount];
@@ -118,6 +144,9 @@ namespace SimplCommerce.Module.Inventory.Tests
             _productRepoMock
                 .Setup(x => x.Query())
                 .Returns(productsMock);
+
+            _stockHistoryRepoMock.Setup(x => x.Add(It.IsAny<StockHistory>()));
+            _stockHistoryRepoMock.Setup(x => x.SaveChangesAsync()).Returns(Task.CompletedTask);
 
             _mediatorMock
                 .Setup(m => m.Send(It.IsAny<ProductBackInStock>(), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
## Summary
- add `RowVersion` timestamp to `Stock` entity
- configure `RowVersion` in `InventoryCustomModelBuilder`
- handle `DbUpdateConcurrencyException` in `StockService`
- add tests for rowversion configuration and concurrency handling

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `bash run-tests.sh` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c55128dc883339796d563d2e7a0af